### PR TITLE
delete anarchy as it is deprecated

### DIFF
--- a/anarchy/anarchy
+++ b/anarchy/anarchy
@@ -1,6 +1,0 @@
-NAME="Anarchy Linux"
-PRETTY_NAME="Anarchy Linux"
-ID=anarchy
-ID_LIKE=anarchylinux
-ANSI_COLOR="0;36"
-HOME_URL="https://anarchylinux.org/"


### PR DESCRIPTION
`anarchy` arch installer is deprecated, see: https://gitlab.com/anarchyinstaller/installer/-/commit/b1c057075160611fbb535e72893f1f4972e73b31