### PR TITLE
feat: omnios/solaris

### DIFF
--- a/omnios/r151048
+++ b/omnios/r151048
@@ -1,0 +1,10 @@
+NAME="OmniOS"
+PRETTY_NAME="OmniOS Community Edition v11 r151048"
+CPE_NAME="cpe:/o:omniosce:omnios:11:151048:0"
+ID=omnios
+VERSION=r151048
+VERSION_ID=r151048
+BUILD_ID=151048.0.2023.11.04
+HOME_URL="https://omnios.org/"
+SUPPORT_URL="https://omnios.org/"
+BUG_REPORT_URL="https://github.com/omniosorg/omnios-build/issues/new"

--- a/solaris/11.4
+++ b/solaris/11.4
@@ -1,0 +1,9 @@
+NAME="Oracle Solaris"
+PRETTY_NAME="Oracle Solaris 11.4"
+CPE_NAME="cpe:/o:oracle:solaris:11:4"
+ID=solaris
+VERSION=11.4
+VERSION_ID=11.4
+BUILD_ID=11.4.0.0.1.15.0
+HOME_URL="https://www.oracle.com/solaris/"
+SUPPORT_URL="https://support.oracle.com/"


### PR DESCRIPTION
Closes #9 
/etc/os-release is not found in OpenIndiana and SmartOS.