### PR TITLE
feat(postmarketos): add v25.12

### DIFF
--- a/postmarketos/v25.12
+++ b/postmarketos/v25.12
@@ -1,0 +1,12 @@
+PRETTY_NAME="postmarketOS v25.12"
+NAME="postmarketOS"
+VERSION_ID="v25.12"
+VERSION="v25.12"
+ID="postmarketos"
+ID_LIKE="alpine"
+HOME_URL="https://www.postmarketos.org/"
+SUPPORT_URL="https://gitlab.postmarketos.org/postmarketOS"
+BUG_REPORT_URL="https://gitlab.postmarketos.org/postmarketOS/pmaports/issues"
+LOGO="postmarketos-logo"
+ANSI_COLOR="0;32"
+


### PR DESCRIPTION
Adds os-release file for postmarketos v25.12 from https://gitlab.postmarketos.org/postmarketOS/pmaports/-/blob/v25.12/main/postmarketos-base/rootfs-usr-lib-os-release